### PR TITLE
Cashflow report v1

### DIFF
--- a/frontend/components/CashflowChart.jsx
+++ b/frontend/components/CashflowChart.jsx
@@ -1,0 +1,203 @@
+// Mithril Components
+const m = require("mithril")
+const HighchartsContainer = require("./HighchartsContainer")
+
+// Application state
+const Category = require("../models/Category")
+const Currency = require("../models/Currency")
+const Model = require("../models/index")
+
+// data manipulation
+const dayjs = require("../dayjs-lib")
+const Util = require("../util/index")
+
+
+/**
+ * A mapping from this application's "grouping" enum to the date format used by
+ * Highcharts. Undefined means to use Highcharts default (full date)
+ */
+const groupingToHighchartsDateFormat = {
+	"day": undefined,
+	"week": undefined,
+	"biweekly": undefined,
+	"month": "%b %Y",
+	"quarter": "%b %Y",
+	"year": "%Y",
+};
+
+
+
+/**
+ * Consider removing this in the future and just rely on the parent component
+ * to filter the data before passing it to this component.
+ */
+const filterCategories = function(categoryStack, data) {
+	return data.filter(object => categoryStack.hasOwnProperty(object["categories"]));
+};
+
+/**
+ * Converts data into a format consumed by Highcharts library
+ * 
+ * @param grouping  day|week|biweekly|month|quarter|year
+ * @param categoryStack  this describes which categories should be included 
+ * in the chart and how they should be grouped. The data type is an object with
+ * key-value pairs. The key is the category's id. The value is a number/string
+ * that identifies which stack it will be a part of. If two values are the same
+ * then those categories will be in the same stack on top of each other.
+ * @param data  a list of objects {
+ * categories: categoryId, 
+ * currencies: currencyId, 
+ * date: "YYYY-MM-DD", 
+ * money: integer}
+ * 
+ * @return a list of Highcharts series configuration objects. Includes tooltip
+ * formatting and all points
+ */
+const createSeries = function(timeGrouping, categoryStack, data) {
+	let axisList = Util.groupBy(data, ["currencies"], function(groupedKeys, items) {
+		return groupedKeys[0];
+	});
+
+	let multipleCurrencies = axisList.length > 1;
+
+	// return a list of Highcharts Series configuration objects
+	// created by grouping the data by currency and category, so each item1 will have a unique currency+category, but different dates within the points
+	return Util.groupBy(data, ["currencies", "categories"], function(groupedKeys, items1) {
+		return {
+			// group the items by their time period (month/quarter/year), and convert to HighCharts point format
+			data: Util.groupBy(
+				items1, 
+				[item1 => dayjs(item1["date"], "YYYY-MM-DD").startOf(timeGrouping).valueOf()], // group by Unix Timestamp of group start
+				(groupedKeys, items2) => [ //convert to array of points. Each point is an array of [unix timestamp (x), sum of money (y)]
+					parseInt(groupedKeys[0]), // Highcharts needs the unix timestamp as an integer, but groupBy turns it into a string
+					items2.reduce(
+						(sum, item2) => sum + parseInt(item2["money"]),
+						0
+					)
+				]).sort( // sort points from earliest to latest timestamp
+					(a, b) => a[0] - b[0]  // unix timestamps can be sorted just like numbers
+				),
+			name: Category.getById(groupedKeys[1]).name + (multipleCurrencies? (" (" + Currency.getById(groupedKeys[0]).iso + ")") : ""),
+			stack: groupedKeys[0] + categoryStack[ groupedKeys[1] ], //to ensure different currencies are never in the same stack
+			tooltip: {
+				pointFormatter: function() {
+					return '<span style="color:' + this.series.color + '">\u25CF</span> ' + this.series.name + ": <b>" + Model.formatMoneyAmount(Math.abs(this.y), groupedKeys[0]) + "</b><br/>";		
+				},
+			},
+		};
+	});
+};
+
+/**
+ * Creates list of Y axes for the chart. Each currency is assigned a Y axis, to
+ * avoid working with exchange rates.
+ */
+const createYAxis = function(data) {
+	return Util.groupBy(data, ["currencies"], function(groupedKeys, items) {
+		return {
+			title: {
+				text: Currency.getById(groupedKeys[0]).name
+			},
+			labels: {
+				formatter: function() {
+					// return Model.formatMoneyAmount(Math.abs(this.value), Currency.getById(groupedKeys[0]));
+					// replace "000" with "K"
+					let v = this.value / Math.pow(10, Currency.getById(groupedKeys[0])["decimals"]);
+					if(Math.abs(v) > 1000) {
+						return ((v / 1000.0) | 0) + "K";
+					}
+					return v|0;
+				}
+			},
+		};
+	});
+}
+
+const createHighchartsOptions = function(timeGrouping, categoryStack, data) {
+	return {
+		series: createSeries(timeGrouping, categoryStack, data),
+		yAxis: createYAxis(data),
+	};
+}
+
+/**
+ * This component draws a grouped column chart. The y axis measures money spent
+ * The x axis measures time. The groups on the x axis are time period groups
+ * like months. The columns represent the money spent in a category. This chart
+ * works with multiple currencies too. If any of the attributes change (shallow
+ * comparison, not deep), the chart will replace the old data.
+ * 
+ * @attribute grouping  see `pages/overview.jsx` for enum
+ * @attribute categoryStack  this describes which categories should be included 
+ * in the chart and how they should be grouped. The data type is an object with
+ * key-value pairs. The key is the category's id. The value is a number/string
+ * that identifies which stack it will be a part of. If two values are the same
+ * then those categories will be in the same stack on top of each other.
+ * @attribute data  a list of objects {
+ * categories: categoryId, 
+ * currencies: currencyId, 
+ * date: "YYYY-MM-DD", 
+ * money: integer}
+ * 
+ */
+module.exports = function() {
+	// component state
+	let oldOptions = {grouping: "month", data: [], categoryStack: {}};
+	let series = [];
+	let yAxis = [];
+
+	return {
+		view: function(vnode) {
+			// update state based on new component attributes
+			let allowChartUpdate = !Util.shallowEquals(oldOptions, vnode.attrs);
+			if(allowChartUpdate) {
+				oldOptions = vnode.attrs;
+				let o = createHighchartsOptions(vnode.attrs.grouping, vnode.attrs.categoryStack, filterCategories(vnode.attrs.categoryStack, vnode.attrs.data));
+				series = o.series;
+				yAxis = o.yAxis;
+			}
+
+			return m(HighchartsContainer, {
+				chartOptions: {
+					chart: {
+						type: "column",
+					},
+					credits: {
+						enabled: false,
+					},
+					legend: {
+						layout: "vertical",
+						align: "right",
+						verticalAlign: "middle",
+					},
+					plotOptions: {
+						column: {
+							stacking: "normal",
+						},
+					},
+					series: series,
+					subtitle: {
+						text: "Compare how much was spent in each category over time. Click on a series in the legend to hide it",
+						align: "left",
+					},
+					title: {
+						text: "Cashflow",
+						align: "left",
+					},
+					tooltip: {
+						shared: true,
+						xDateFormat: groupingToHighchartsDateFormat[vnode.attrs.grouping], //format the tooltip date
+					},
+					xAxis: {
+						labels: {
+							format: groupingToHighchartsDateFormat[vnode.attrs.grouping]? ("{value:" + groupingToHighchartsDateFormat[vnode.attrs.grouping] + "}") : undefined,
+						},
+						type: "datetime",
+					},
+					yAxis: yAxis,
+				},
+				allowChartUpdate: allowChartUpdate,
+			});
+		},
+	};
+}

--- a/frontend/components/CashflowInteractive.jsx
+++ b/frontend/components/CashflowInteractive.jsx
@@ -1,0 +1,211 @@
+// Mithril Components
+const m = require("mithril")
+const CashflowChart = require("./CashflowChart")
+const CategoryPicker = require("./CategoryPicker")
+const {Button, ModalPanel, Select} = require("mithril-materialized")
+
+// API and application state
+const Category = require("../models/Category")
+const Report = require("../models/Report")
+
+// data manipulation
+const dayjs = require("../dayjs-lib")
+const Util = require("../util/index")
+
+
+
+/**
+ * Given spending broken down by categories, create some new data points with
+ * totals for all expenses, incomes, and net income.
+ */
+const createNetCategory = function(data) {
+	// rather than using the return value of groupBy(), this approach modifies the data parameter on each iteration
+	Util.groupBy(data, ["date", "currencies", "wallets"], function(groupedKeys, oneDayAllCategories) {
+		let expenses = 0;
+		let income = 0;
+		for(let oneDayOneCategory of oneDayAllCategories) {
+			if(oneDayOneCategory["categories_type"] == Category.TYPE_EXPENSE) {
+				expenses += parseInt(oneDayOneCategory["money"]);
+			} else if(oneDayOneCategory["categories_type"] == Category.TYPE_INCOME) {
+				income += parseInt(oneDayOneCategory["money"]);
+			}
+		}
+		data.push({
+			date: groupedKeys[0],
+			categories: Category.CATEGORY_ALL_EXPENSES,
+			currencies: groupedKeys[1],
+			money: expenses,
+			wallets: groupedKeys[2],
+		});
+		data.push({
+			date: groupedKeys[0],
+			categories: Category.CATEGORY_ALL_INCOME,
+			currencies: groupedKeys[1],
+			money: income,
+			wallets: groupedKeys[2],
+		});
+		data.push({
+			date: groupedKeys[0],
+			categories: Category.CATEGORY_NET_INCOME,
+			currencies: groupedKeys[1],
+			money: income - expenses,
+			wallets: groupedKeys[2],
+		});
+		return 0;
+	});
+}
+
+// AJAX/fetch request status options
+const WAITING = 1, READY = 2, ERROR = 3;
+
+// Other constants
+const NO_CATEGORY_SELECTED = null;
+
+
+/**
+ * This component is a wrapper around CashflowChart. On initialization, it
+ * fetches category spending data. Then, it calculates the net income. Finally,
+ * it displays the column chart. Below the chart is a button which opens a
+ * modal to add a category to the chart (in a new series or a grouped one).
+ * 
+ * TODO: known issue: the chart won't apply filters immediately upon creation
+ * 
+ * Attributes:
+ * @attribute grouping  this is passed directly to CashflowChart, see docs
+ * @attribute filters  an object with startDate (DayJS), endDate (Dayjs),
+ * and wallets (string id or "Total").
+ */
+
+module.exports = function(initialVnode) {
+	// instance state
+	let status = WAITING;
+	let allData = []; // unfiltered
+	let data = []; // filtered
+	let modalOpen = false;
+	let categoryStack = {}; // mapping of {categoryId: stack} for the chart
+	let stackToCategories = {}; // mapping of {stack: categoryNames} for the dropdown
+	let nextStackName = 10; // counter to give each stack a unique name
+	let filters = Object.assign({startDate: null, endDate: null, wallets: "Total"}, initialVnode.attrs.filters);
+	// new series options from modal
+	let selectedCategory = NO_CATEGORY_SELECTED;
+	let selectedStackName = nextStackName;
+
+	// instance methods
+
+	/**
+	 * Uses filters to narrow the "allData" list into "data" list. The filters
+	 * are passed as attributes to this component.
+	 */
+	const applyFilters = function() {
+		data = allData.filter(
+			(item, index) => ((item["wallets"] == filters["wallets"] || "Total" == filters["wallets"]) && (dayjs(item["date"], "YYYY-MM-DD").isBetween(filters.startDate, filters.endDate, "day", "[]")))
+		);
+	}
+
+	/**
+	 * Uses the API to fetch all data for all time. This will later be filtered
+	 * and grouped as necessary. In addition, synthetic categories are added to
+	 * the mix.
+	 */
+	const fetchData = function() {
+		Report.getDailyCategorySpend("Total").then(function(response) {
+			allData = response;
+			createNetCategory(allData);
+			applyFilters();
+			status = READY;
+		}).catch(function(error) {
+			status = ERROR;
+		}).finally(m.redraw) // must call manually if not using mithril's request()
+	}
+
+	/**
+	 * Adds a series to the chart.
+	 */
+	const addSeries = function(categoryId, stackName) {
+		categoryStack = Object.assign({[categoryId] : stackName}, categoryStack);
+		if(stackToCategories.hasOwnProperty(stackName)) {
+			stackToCategories[stackName] += " / " + Category.getById(categoryId).name;
+		} else {
+			stackToCategories[stackName] = Category.getById(categoryId).name;
+		}
+		nextStackName++;
+	}
+
+
+	
+	// initialize
+	addSeries(Category.CATEGORY_NET_INCOME, 2);
+	applyFilters();
+
+	// view
+	return {
+		view: function(vnode) {
+			const { grouping } = vnode.attrs;
+
+			return m("div", [
+				(status == ERROR) && m("div.red.lighten-3", "Could not fetch data for this chart"),
+				(status == WAITING) && m("div.teal.lighten-3", "Loading data"),
+				m(CashflowChart, {grouping: grouping, data: data, categoryStack: categoryStack}),
+				m(Button, {
+					label: "Add series",
+					onclick: () => {modalOpen = true;},
+				}),
+				m(Button, {
+					label: "Reset",
+					onclick: () => {
+						categoryStack = {}; 
+						stackToCategories = {}; 
+					},
+				}),
+				m(ModalPanel, {
+					title: "Add Category to Cashflow Chart",
+					description: m("div", [
+						m(Select, {
+							label: "Select whether you'd like to stack this category on top of any series already in the chart",
+							options: [
+								{id: nextStackName, group: "Separate", label: "Create new series"},
+								...(Object.entries(stackToCategories).map(
+									entry => {return {id: entry[0], group: "Add to", label: entry[1]}}
+								))
+							],
+							checkedId: [selectedStackName],
+							onchange: (ids) => {selectedStackName = ids[0];}
+						}),
+						m(CategoryPicker, {
+							showMetaCategories: true,
+							selectedIds: selectedCategory == NO_CATEGORY_SELECTED? [] : [selectedCategory],
+							onselection: (selectedIds) => {if(selectedIds.length > 0) selectedCategory = selectedIds[0];}
+						}),
+					]),
+					isOpen: modalOpen,
+					onToggle: open => {
+						modalOpen = open; 
+						selectedStackName = nextStackName; //reset form state
+						selectedCategory = NO_CATEGORY_SELECTED;
+					},
+					buttons: [
+						{
+							label: "Add",
+							onclick: () => {
+								if(selectedCategory != NO_CATEGORY_SELECTED) {
+									addSeries(selectedCategory, selectedStackName);
+									selectedCategory = NO_CATEGORY_SELECTED;
+								}
+							},
+						}
+					],
+				}),
+			]);
+		},
+		oninit: fetchData,
+		onupdate: function(vnode) {
+			if(vnode.attrs.filters.wallets != filters.wallets ||
+				!vnode.attrs.filters.startDate.isSame(filters.startDate, "day") ||
+				!vnode.attrs.filters.endDate.isSame(filters.endDate, "day")
+				) {
+				filters = vnode.attrs.filters;
+				applyFilters();
+			}
+		}
+	};
+}

--- a/frontend/components/CategoryItem.jsx
+++ b/frontend/components/CategoryItem.jsx
@@ -5,10 +5,10 @@ const Icon = require("./Icon.jsx")
 module.exports = {
 	view: function(vnode) {
 		return (
-			<a onClick={vnode.attrs.onClick}>
-				<Icon icon={{type: "color", name: "FA", color: "orange"}} />
+			<span onclick={vnode.attrs.onclick}>
+				<Icon icon={vnode.attrs.category.icon} marginX={true} />
 				{vnode.attrs.category.name}
-			</a>
+			</span>
 		)
 	}
 };

--- a/frontend/components/CategoryPicker.jsx
+++ b/frontend/components/CategoryPicker.jsx
@@ -1,0 +1,370 @@
+const m = require("mithril")
+const CategoryItem = require("./CategoryItem")
+const TabsOld = require("../components/Tabs.jsx")
+const Tree = require("../components/Tree.jsx")
+const {MaterialIcon, Tabs} = require("mithril-materialized")
+
+const Category = require("../models/Category")
+
+
+/**********************************************************
+ * the following is modified from Mithril-Materialized
+ **********************************************************/
+
+// Utility function to check if a node is the last in its branch
+const isNodeLastInBranch = (nodePath, rootNodes) => {
+    // Navigate to the node's position and check if it's the last child at every level
+    let currentNodes = rootNodes;
+    for (let i = 0; i < nodePath.length; i++) {
+        const index = nodePath[i];
+        const isLastAtThisLevel = index === currentNodes.length - 1;
+        // If this is not the last child at this level, then this node is not last in branch
+        if (!isLastAtThisLevel) {
+            return false;
+        }
+        // Move to the next level if it exists
+        if (i < nodePath.length - 1) {
+            const currentNode = currentNodes[index];
+            if (currentNode.children) {
+                currentNodes = currentNode.children;
+            }
+        }
+    }
+    return true;
+};
+const TreeNodeComponent = () => {
+    return {
+        view: ({ attrs }) => {
+            const { node, level, isSelected, isExpanded, isFocused, showConnectors, iconType, selectionMode, onToggleExpand, onToggleSelect, onFocus, } = attrs;
+            const hasChildren = node.children && node.children.length > 0;
+            const indentLevel = level * 24; // 24px per level
+            return m('li.tree-node', {
+                class: [
+                    isSelected && 'selected',
+                    isFocused && 'focused',
+                    node.disabled && 'disabled',
+                    hasChildren && 'has-children',
+                    attrs.isLastInBranch && 'tree-last-in-branch',
+                ]
+                    .filter(Boolean)
+                    .join(' ') || undefined,
+                'data-node-id': node.id,
+                'data-level': level,
+            }, [
+                // Node content
+                m('.tree-node-content', {
+                    style: {
+                        paddingLeft: `${indentLevel}px`,
+                    },
+                    onclick: node.disabled
+                        ? undefined
+                        : () => {
+                            if (selectionMode !== 'none') {
+                                onToggleSelect(node.id);
+                            }
+                            onFocus(node.id);
+                        },
+                    onkeydown: (e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            if (!node.disabled && selectionMode !== 'none') {
+                                onToggleSelect(node.id);
+                            }
+                        }
+                    },
+                    tabindex: node.disabled ? -1 : 0,
+                    role: selectionMode === 'multiple' ? 'option' : 'treeitem',
+                    'aria-selected': selectionMode !== 'none' ? isSelected.toString() : undefined,
+                    'aria-expanded': hasChildren ? isExpanded.toString() : undefined,
+                    'aria-disabled': node.disabled ? 'true' : undefined,
+                }, [
+                    // Connector lines
+                    showConnectors &&
+                        level > 0 &&
+                        m('.tree-connectors', Array.from({ length: level }, (_, i) => m('.tree-connector', {
+                            key: i,
+                            style: { left: `${i * 24 + 12}px` },
+                        }))),
+                    // Expand/collapse icon or spacer
+                    hasChildren
+                        ? m('.tree-expand-icon', {
+                            onclick: (e) => {
+                                e.stopPropagation();
+                                if (!node.disabled) {
+                                    onToggleExpand(node.id);
+                                }
+                            },
+                            class: iconType,
+                        }, [
+                            iconType === 'plus-minus'
+                                ? m('span.tree-plus-minus', isExpanded ? '−' : '+')
+                                : iconType === 'triangle'
+                                    ? m('span.tree-triangle', { class: isExpanded ? 'expanded' : undefined }, '▶')
+                                    : iconType === 'chevron'
+                                        ? m(MaterialIcon, {
+                                            name: 'chevron',
+                                            direction: isExpanded ? 'down' : 'right',
+                                            class: 'tree-chevron-icon',
+                                        })
+                                        : m(MaterialIcon, {
+                                            name: 'caret',
+                                            direction: isExpanded ? 'down' : 'right',
+                                            class: 'tree-caret-icon',
+                                        }),
+                        ])
+                        : m('.tree-expand-spacer'), // Spacer for alignment
+                    // Selection indicator for multiple selection
+                    selectionMode === 'multiple' &&
+                        m('.tree-selection-indicator', [
+                            m('input[type=checkbox]', {
+                                checked: isSelected,
+                                disabled: node.disabled,
+                                onchange: () => {
+                                    if (!node.disabled) {
+                                        onToggleSelect(node.id);
+                                    }
+                                },
+                                onclick: (e) => e.stopPropagation(),
+                            }),
+                        ]),
+                    // Node icon (optional)
+                    //node.icon && m('i.tree-node-icon.material-icons', node.icon),
+                    // Node label
+                    m(CategoryItem, {category: node}),
+                    //m('span.tree-node-label', node.label),
+                ]),
+                // Children (recursive)
+                hasChildren &&
+                    isExpanded &&
+                    m('ul.tree-children', {
+                        role: 'group',
+                        'aria-expanded': 'true',
+                    }, node.children.map((child, childIndex) => {
+                        var _a, _b, _c, _d, _e, _f;
+                        // Calculate state for each child using treeState
+                        const childIsSelected = (_b = (_a = attrs.treeState) === null || _a === void 0 ? void 0 : _a.selectedIds.has(child.id)) !== null && _b !== void 0 ? _b : false;
+                        const childIsExpanded = (_d = (_c = attrs.treeState) === null || _c === void 0 ? void 0 : _c.expandedIds.has(child.id)) !== null && _d !== void 0 ? _d : false;
+                        const childIsFocused = ((_e = attrs.treeState) === null || _e === void 0 ? void 0 : _e.focusedNodeId) === child.id;
+                        // Calculate if this child is last in branch
+                        const childPath = [...(attrs.currentPath || []), childIndex];
+                        const childIsLastInBranch = ((_f = attrs.treeAttrs) === null || _f === void 0 ? void 0 : _f.data) ?
+                            isNodeLastInBranch(childPath, attrs.treeAttrs.data) : false;
+                        return m(TreeNodeComponent, {
+                            key: child.id,
+                            node: child,
+                            level: level + 1,
+                            isSelected: childIsSelected,
+                            isExpanded: childIsExpanded,
+                            isFocused: childIsFocused,
+                            showConnectors,
+                            iconType,
+                            selectionMode,
+                            onToggleExpand,
+                            onToggleSelect,
+                            onFocus,
+                            isLastInBranch: childIsLastInBranch,
+                            currentPath: childPath,
+                            treeState: attrs.treeState,
+                            treeAttrs: attrs.treeAttrs,
+                        });
+                    })),
+            ]);
+        },
+    };
+};
+const TreeView = () => {
+    const state = {
+        selectedIds: new Set(),
+        expandedIds: new Set(),
+        focusedNodeId: null,
+        treeMap: new Map(),
+    };
+    const buildTreeMap = (nodes, map) => {
+        nodes.forEach((node) => {
+            map.set(node.id, node);
+            if (node.children) {
+                buildTreeMap(node.children, map);
+            }
+        });
+    };
+    const initializeExpandedNodes = (nodes) => {
+        nodes.forEach((node) => {
+            if (node.expanded) {
+                state.expandedIds.add(node.id);
+            }
+            if (node.children) {
+                initializeExpandedNodes(node.children);
+            }
+        });
+    };
+    const handleToggleExpand = (nodeId, attrs) => {
+        var _a;
+        const isExpanded = state.expandedIds.has(nodeId);
+        if (isExpanded) {
+            state.expandedIds.delete(nodeId);
+        }
+        else {
+            state.expandedIds.add(nodeId);
+        }
+        (_a = attrs.onexpand) === null || _a === void 0 ? void 0 : _a.call(attrs, { nodeId, expanded: !isExpanded });
+    };
+    const handleToggleSelect = (nodeId, attrs) => {
+        var _a;
+        const { selectionMode = 'single' } = attrs;
+        if (selectionMode === 'single') {
+            state.selectedIds.clear();
+            state.selectedIds.add(nodeId);
+        }
+        else if (selectionMode === 'multiple') {
+            if (state.selectedIds.has(nodeId)) {
+                state.selectedIds.delete(nodeId);
+            }
+            else {
+                state.selectedIds.add(nodeId);
+            }
+        }
+        (_a = attrs.onselection) === null || _a === void 0 ? void 0 : _a.call(attrs, Array.from(state.selectedIds));
+    };
+    const handleFocus = (nodeId) => {
+        state.focusedNodeId = nodeId;
+    };
+    const renderNodes = (nodes, attrs, level = 0, parentPath = []) => {
+        return nodes.map((node, index) => {
+            var _a, _b, _c;
+            const isSelected = state.selectedIds.has(node.id);
+            const isExpanded = state.expandedIds.has(node.id);
+            const isFocused = state.focusedNodeId === node.id;
+            const currentPath = [...parentPath, index];
+            const isLastInBranch = isNodeLastInBranch(currentPath, attrs.data);
+            return m(TreeNodeComponent, {
+                key: node.id,
+                node,
+                level,
+                isSelected,
+                isExpanded,
+                isFocused,
+                showConnectors: (_a = attrs.showConnectors) !== null && _a !== void 0 ? _a : true,
+                iconType: (_b = attrs.iconType) !== null && _b !== void 0 ? _b : 'caret',
+                selectionMode: (_c = attrs.selectionMode) !== null && _c !== void 0 ? _c : 'single',
+                onToggleExpand: (nodeId) => handleToggleExpand(nodeId, attrs),
+                onToggleSelect: (nodeId) => handleToggleSelect(nodeId, attrs),
+                onFocus: handleFocus,
+                isLastInBranch,
+                currentPath,
+                // Pass state and attrs for recursive rendering
+                treeState: state,
+                treeAttrs: attrs,
+            });
+        });
+    };
+    return {
+        oninit: ({ attrs }) => {
+            // Build internal tree map for efficient lookups
+            buildTreeMap(attrs.data, state.treeMap);
+            // Initialize expanded nodes from data
+            initializeExpandedNodes(attrs.data);
+            // Initialize selected nodes from props
+            if (attrs.selectedIds) {
+                state.selectedIds = new Set(attrs.selectedIds);
+            }
+        },
+        onupdate: ({ attrs }) => {
+            // Sync selectedIds prop with internal state
+            if (attrs.selectedIds) {
+                const newSelection = new Set(attrs.selectedIds);
+                if (newSelection.size !== state.selectedIds.size ||
+                    !Array.from(newSelection).every((id) => state.selectedIds.has(id))) {
+                    state.selectedIds = newSelection;
+                }
+            }
+        },
+        view: ({ attrs }) => {
+            const { data, className, style, id, selectionMode = 'single', showConnectors = true } = attrs;
+            return m('div.tree-view', {
+                class: [
+                    className,
+                    showConnectors && 'show-connectors'
+                ].filter(Boolean).join(' ') || undefined,
+                style,
+                id,
+                role: selectionMode === 'multiple' ? 'listbox' : 'tree',
+                'aria-multiselectable': selectionMode === 'multiple' ? 'true' : 'false',
+            }, [
+                m('ul.tree-root', {
+                    role: 'group',
+                }, renderNodes(data, attrs)),
+            ]);
+        },
+    };
+};
+
+
+
+/**
+ * This component renders a UI widget that shows the category tree. The user
+ * interacts by clicking on a category. The results of the selection are
+ * revealed in an event listener.
+ * 
+ * Attributes:
+ * 
+ * @attribute selectedIds  array of category IDs. If present, then this is a
+ * "controlled" component, meaning the state is managed outside the component.
+ * Use onselection and selectedIds to get/set the state.
+ * It may be an empty list to clear the selection.
+ * 
+ * @attribute multiple  boolean, default false. If false, then only one category
+ * can be selected at a time. When the selection is made the event is fired. If
+ * true, then multiple categories can be part of a selection.
+ * 
+ * @attribute onselection  event listener callback function. This function will be
+ * called when a selection is made. It should accept one parameter, an array of
+ * Category IDs. If multiple=false, then there will only be one item in the
+ * array.
+ * 
+ * @attribute showMetaCategories  boolean, default false. If true, then the 
+ * options will include meta categories computer by the app like "All Income".
+ */
+
+module.exports = (function() {
+	return {
+		view: function(vnode) {
+			return m(Tabs, {
+				tabs: [
+					{
+						title: "Income",
+						vnode: m(TreeView, {
+                            data: vnode.attrs.showMetaCategories? Category.getIncomeTree() : Category.getTree(Category.income),
+							selectionMode: vnode.attrs.multiple? "multiple" : "single",
+							selectedIds: vnode.attrs.selectedIds,
+							iconType: "caret",
+							showConnectors: true,
+							onselection: vnode.attrs.onselection,
+						}),
+					},
+					{
+						title: "Expenses",
+						vnode: m(TreeView, {
+							data: vnode.attrs.showMetaCategories? Category.getExpenseTree() : Category.getTree(Category.expense),
+							selectionMode: vnode.attrs.multiple? "multiple" : "single",
+							selectedIds: vnode.attrs.selectedIds,
+							iconType: "caret",
+							showConnectors: true,
+							onselection: vnode.attrs.onselection,
+						}),
+					},
+					{
+						title: "System",
+						vnode: m(TreeView, {
+							data: Category.getTree(Category.system),
+							selectionMode: vnode.attrs.multiple? "multiple" : "single",
+							selectedIds: vnode.attrs.selectedIds,
+							iconType: "caret",
+							showConnectors: true,
+							onselection: vnode.attrs.onselection,
+						}),
+					},
+				],
+			});
+		}
+	};
+})

--- a/frontend/models/Category.js
+++ b/frontend/models/Category.js
@@ -13,6 +13,12 @@ var Category = {
 	DIRECTION_INCOME: 1, //same value as Transaction.direction
 	DIRECTION_BOTH: 2, //only used for Transfer category to exclude from some reports
 
+	CATEGORY_USER_EXPENSES: 0, //used by cash flow chart as a meta category
+	CATEGORY_USER_INCOME: 1, //used by cash flow chart as a meta category
+	CATEGORY_ALL_EXPENSES: 2, //used by cash flow chart as a meta category
+	CATEGORY_ALL_INCOME: 3, //used by cash flow chart as a meta category
+	CATEGORY_NET_INCOME: 4, //used by cash flow chart as a meta category
+
 	loadList: function() {
 		return pb.collection('categories').getFullList({
 			sort: 'index'
@@ -28,6 +34,30 @@ var Category = {
 		categories_list.forEach(category => {
 			Category.byId[ category["id"] ] = category;
 		});
+		Category.byId[Category.CATEGORY_ALL_INCOME] = {
+			id: Category.CATEGORY_ALL_INCOME,
+			name: "All Income",
+			icon: {type: "color", "name": "I", color: "#3495eb"},
+			type: Category.TYPE_INCOME,
+			show_in_report: true,
+			parent: "",
+		};
+		Category.byId[Category.CATEGORY_ALL_EXPENSES] = {
+			id: Category.CATEGORY_ALL_EXPENSES,
+			name: "All Expenses",
+			icon: {type: "color", "name": "E", color: "#c95d0a"},
+			type: Category.TYPE_INCOME,
+			show_in_report: true,
+			parent: "",
+		};
+		Category.byId[Category.CATEGORY_NET_INCOME] = {
+			id: Category.CATEGORY_NET_INCOME,
+			name: "Net Income",
+			icon: {type: "color", "name": "N", color: "#c95d0a"},
+			type: Category.CATEGORY_NET_INCOME,
+			show_in_report: true,
+			parent: "",
+		};
 
 		return categories_list;
 	},
@@ -49,6 +79,14 @@ var Category = {
 			category.children = Category.getTree(categories, category["id"]);
 		}
 		return tree_level;
+	},
+
+	getExpenseTree: function() {
+		return Category.getTree(Category.expense.concat([Category.getById(Category.CATEGORY_ALL_EXPENSES)]));
+	},
+
+	getIncomeTree: function() {
+		return Category.getTree(Category.income.concat([Category.getById(Category.CATEGORY_ALL_INCOME)]));
 	},
 
 	/**

--- a/frontend/models/Report.js
+++ b/frontend/models/Report.js
@@ -81,6 +81,12 @@ const Report = {
 		})
 	},
 	moneyPerCategoryCache: null,
+
+	getDailyCategorySpend: function(wallet) {
+		return pb.collection("categories_daily").getFullList({
+			filter: (wallet == "Total")? "" : pb.filter("wallets = {:wallet}", {wallet}),
+		})
+	},
 };
 
 module.exports = Report;

--- a/frontend/pages/overview.jsx
+++ b/frontend/pages/overview.jsx
@@ -1,5 +1,6 @@
 const m = require("mithril")
 const HighchartsContainer = require("../components/HighchartsContainer")
+const CashflowInteractive = require("../components/CashflowInteractive")
 
 const Currency = require("../models/Currency")
 const Report = require("../models/Report")
@@ -307,11 +308,11 @@ module.exports = function() {
 						</div>
 						<div class="col s6 m4 input-field">
 							<label class="active">Wallet:</label>
-							<select class="browser-default">
+							<select class="browser-default" onchange={e => {allowChartUpdate=true; wallets=e.target.value}}>
 								{Wallet.list.map(function(wallet) {
-									return (<option value={wallet.id} key={wallet.id}>{wallet.name}</option>)
+									return (<option value={wallet.id} key={wallet.id} selected={wallets == wallet.id}>{wallet.name}</option>)
 								})}
-								<option value="Total" selected>Total</option>
+								<option value="Total" selected={wallets == "Total"}>Total</option>
 							</select>
 						</div>
 						<button class="col s12 btn waves-effect waves-light" type="submit">
@@ -324,6 +325,7 @@ module.exports = function() {
 						chartOptions={netWorthOptions} 
 						chartCreatedCallback={extendNetWorthChart}
 						allowChartUpdate={allowChartUpdate} />
+					<CashflowInteractive filters={{startDate: startDate, endDate: endDate, wallets: wallets}} grouping={grouping} />
 				</div>
 			);
 		}


### PR DESCRIPTION
Added an interactive cashflow report to the Overview page, below the Net Worth chart.

Features:
- Respects date and wallet filters on the report
- Uses the grouping setting to transform the chart
- Modal to add any category to the chart
- You can stack categories on each other to make a "sum"
- "All user income" and "all user expenses" meta categories
- reusable components

Room for improvement:
- Add more meta categories, especially the "Net income" to the category picker